### PR TITLE
add basename option to codegen for network alternatives

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char **argv) {
   std::string weight_dir_str;
   std::string bin_dir_str;
   std::string module_name;
+  std::string basename;
   bool mkdir = false;
 
   // Positional: DNX artifact
@@ -46,6 +47,7 @@ int main(int argc, char **argv) {
 
   app.add_option("--bin-dir", bin_dir_str, "vkdt binary directory");
 
+  app.add_option("--basename", basename, "base/variant name of the network");
   app.add_option("--module-name", module_name, "Name of the vkdt module")
       ->required();
 
@@ -113,12 +115,12 @@ int main(int argc, char **argv) {
   vkdt_denox::CompressedWeights compressed_weights =
       vkdt_denox::compress_weights(dnx);
   vkdt_denox::ShaderRegistry shader_registry =
-      vkdt_denox::create_shader_registry(dnx);
+      vkdt_denox::create_shader_registry(dnx, basename);
   vkdt_denox::ComputeGraph compute_graph =
       vkdt_denox::reconstruct_compute_graph(dnx, compressed_weights);
 
   fs::path weight_path =
-      weight_dir / fmt::format("{}-weights.dat", module_name);
+      weight_dir / fmt::format("{}-{}.dat", module_name, basename);
   std::string weight_path_str = weight_path.string();
   std::string rel_weight_path_str = fs::relative(weight_path, bin_dir).string();
   fmt::println("relative-path: {}", rel_weight_path_str);
@@ -133,18 +135,18 @@ int main(int argc, char **argv) {
   }
 
   vkdt_denox::SourceWriter src;
-  src.add_header_guard(fmt::format("{}_DENOX_MODULE_H", module_name));
+  src.add_header_guard(fmt::format("{}_{}_DENOX_MODULE_H", module_name, basename));
   src.append("\n");
   vkdt_denox::def_func_denox_read_source(src, compute_graph, compressed_weights,
-                                         rel_weight_path_str, module_name);
+                                         rel_weight_path_str, module_name, basename);
 
   src.append("\n");
   vkdt_denox::def_func_denox_create_nodes(src, dnx, symbolic_ir,
                                           shader_registry, compressed_weights,
-                                          compute_graph, module_name);
+                                          compute_graph, module_name, basename);
   src.append("\n");
 
-  fs::path src_path = src_dir / "denox_model.h";
+  fs::path src_path = src_dir / ("denox_" + basename + ".h");
   vkdt_denox::write_file(src_path, src.finish());
   return 0;
 }

--- a/codegen/denox_create_nodes.cpp
+++ b/codegen/denox_create_nodes.cpp
@@ -622,14 +622,15 @@ void vkdt_denox::def_func_denox_create_nodes(
     SourceWriter &src, const denox::dnx::Model *dnx,
     const SymbolicIR &symbolic_ir, const ShaderRegistry &shader_registery,
     const CompressedWeights &compresed_weights,
-    const ComputeGraph &compute_graph, const std::string_view module_name) {
+    const ComputeGraph &compute_graph,
+    const std::string_view module_name,
+    const std::string &basename) {
   src.add_include("stdint.h", IncludeType::System);
   src.add_include("string.h", IncludeType::System);
   src.add_include("stddef.h", IncludeType::System);
   src.add_include("modules/api.h", IncludeType::Local);
 
-  std::string def =
-      "static void denox_create_nodes(dt_graph_t* graph, dt_module_t* module";
+  std::string def = fmt::format("static void denox_create_nodes_{}(dt_graph_t* graph, dt_module_t* module", basename);
   if (symbolic_ir.vars.empty()) {
     def.append(") {");
     src.append(def);

--- a/codegen/denox_create_nodes.cpp
+++ b/codegen/denox_create_nodes.cpp
@@ -490,11 +490,12 @@ static void create_graph(SourceWriter &src, const SymbolicIR &symbolic_ir,
                     static_cast<const denox::dnx::ScalarLiteral *>(
                         sinksource.tensor_offset->ptr)) +
                 sinksource.buffer_ssbo_offset;
-            offset_src.append(fmt::format(
-                "graph->node[{}_id].connector[{}].ssbo_offset = {};",
-                node_namespace, i, sinksource.buffer_ssbo_offset));
+            if(offset)
+              offset_src.append(fmt::format(
+                    "graph->node[{}_id].connector[{}].ssbo_offset = {};",
+                    node_namespace, i, sinksource.buffer_ssbo_offset));
           } else {
-            if (sinksource.buffer_ssbo_offset != 0) {
+            if (sinksource.buffer_ssbo_offset == 0) {
               offset_src.append(fmt::format(
                   "graph->node[{}_id].connector[{}].ssbo_offset = {};",
                   node_namespace, i,

--- a/codegen/denox_create_nodes.cpp
+++ b/codegen/denox_create_nodes.cpp
@@ -474,6 +474,14 @@ static void create_graph(SourceWriter &src, const SymbolicIR &symbolic_ir,
       for (uint32_t i = 0; i < node.sinksources.size(); ++i) {
         const SinkSource &sinksource = node.sinksources[i];
 
+#if 0
+        // try to clear write outputs, doesn't change anything
+        if(sinksource.type == vkdt_denox::SinkSourceType::Write)
+            offset_src.append(fmt::format(
+                "graph->node[{}_id].connector[{}].flags |= s_conn_clear;",
+                node_namespace, i));
+#endif
+
         if (sinksource.tensor_offset.has_value()) {
           if (sinksource.tensor_offset->type ==
               denox::dnx::ScalarSource_literal) {

--- a/codegen/denox_create_nodes.cpp
+++ b/codegen/denox_create_nodes.cpp
@@ -374,6 +374,7 @@ static void create_graph(SourceWriter &src, const SymbolicIR &symbolic_ir,
       assert(!node.sinksources.empty());
       for (uint32_t i = 0; i < node.sinksources.size(); ++i) {
         const auto &sinksource = node.sinksources[i];
+        // FIXME should be dt_no_roi for "read" type of connectors
         std::string sinksource_desc = fmt::format(
             "\"{}\", \"{}\", \"{}\", \"{}\", &roi{}", sinksource.name,
             sinksource_type_to_string(sinksource.type),

--- a/codegen/denox_create_nodes.hpp
+++ b/codegen/denox_create_nodes.hpp
@@ -13,6 +13,7 @@ void def_func_denox_create_nodes(SourceWriter &src, const denox::dnx::Model *dnx
                           const ShaderRegistry &shader_registery,
                           const CompressedWeights &compresed_weights,
                           const ComputeGraph &compute_graph,
-                          const std::string_view module_name);
+                          const std::string_view module_name,
+                          const std::string &basename);
 
 } // namespace vkdt_denox

--- a/codegen/denox_read_source.cpp
+++ b/codegen/denox_read_source.cpp
@@ -6,12 +6,13 @@
 void vkdt_denox::def_func_denox_read_source(
     SourceWriter &src, const ComputeGraph &compute_graph,
     const CompressedWeights &compressed_weights, std::string_view weights_path,
-    std::string_view module_name) {
+    std::string_view module_name,
+    std::string &basename) {
   src.add_include("stdint.h", IncludeType::System);
   src.add_include("stdio.h", IncludeType::System);
   src.add_include("modules/api.h", IncludeType::Local);
 
-  src.append("static int denox_read_source(dt_module_t* mod, void* mapped, "
+  src.append("static int denox_read_source_"+basename+"(dt_module_t* mod, void* mapped, "
              "dt_read_source_params_t* p) {");
   src.push_indentation();
   bool first = true;

--- a/codegen/denox_read_source.hpp
+++ b/codegen/denox_read_source.hpp
@@ -9,6 +9,7 @@ void def_func_denox_read_source(SourceWriter &src,
                                 const ComputeGraph &compute_graph,
                                 const CompressedWeights &compressed_weights,
                                 std::string_view weights_path,
-                                std::string_view module_name);
+                                std::string_view module_name,
+                                std::string &basename);
 
 } // namespace vkdt_denox

--- a/codegen/main.cpp
+++ b/codegen/main.cpp
@@ -11,8 +11,9 @@
 #include <filesystem>
 #include <fmt/format.h>
 
-int main() {
-
+int main()
+{
+  std::string basename = "comp";
   // Read dnx file from disk.
   std::string dnx_path = "./net.dnx";
   std::vector<uint8_t> dnx_buffer = vkdt_denox::read_file_bytes(dnx_path);
@@ -24,7 +25,7 @@ int main() {
   vkdt_denox::CompressedWeights compressed_weights =
       vkdt_denox::compress_weights(dnx);
   vkdt_denox::ShaderRegistry shader_registry =
-      vkdt_denox::create_shader_registry(dnx);
+      vkdt_denox::create_shader_registry(dnx, basename);
   vkdt_denox::ComputeGraph compute_graph =
       vkdt_denox::reconstruct_compute_graph(dnx, compressed_weights);
 
@@ -50,17 +51,17 @@ int main() {
 
   std::string weights_path_str = weights_path.string();
   vkdt_denox::SourceWriter src;
-  src.add_header_guard(fmt::format("{}_CREATE_DNX_NODES_H", module_name));
+  src.add_header_guard(fmt::format("{}_{}_CREATE_DNX_NODES_H", basename, module_name));
 
   src.append("\n");
   vkdt_denox::def_func_denox_read_source(src, compute_graph, compressed_weights,
-                                         weights_path_str, module_name);
+                                         weights_path_str, module_name, basename);
 
   src.append("\n");
   vkdt_denox::def_func_denox_create_nodes(src, dnx, symbolic_ir,
-  shader_registry,
-                                        compressed_weights, compute_graph,
-                                        module_name);
+      shader_registry,
+      compressed_weights, compute_graph,
+      module_name, basename);
   src.append("\n");
 
   vkdt_denox::write_file(module_dir / "denox_model.h", src.finish());

--- a/codegen/shader_registry.cpp
+++ b/codegen/shader_registry.cpp
@@ -2,7 +2,7 @@
 #include <fmt/format.h>
 
 vkdt_denox::ShaderRegistry
-vkdt_denox::create_shader_registry(const denox::dnx::Model *dnx) {
+vkdt_denox::create_shader_registry(const denox::dnx::Model *dnx, std::string &basename) {
 
   const uint32_t binary_count = dnx->shader_binaries()->size();
 
@@ -11,7 +11,7 @@ vkdt_denox::create_shader_registry(const denox::dnx::Model *dnx) {
 
   for (uint32_t i = 0; i < binary_count; ++i) {
     const auto *binary = dnx->shader_binaries()->Get(i);
-    registry.binaries[i].name = fmt::format("comp{}", i);
+    registry.binaries[i].name = fmt::format("{}{}", basename, i);
     registry.binaries[i].spv = std::span<const uint32_t>{
         binary->spirv()->data(), binary->spirv()->size()};
   }

--- a/codegen/shader_registry.hpp
+++ b/codegen/shader_registry.hpp
@@ -16,6 +16,6 @@ struct ShaderRegistry {
   std::vector<ShaderBinary> binaries;
 };
 
-ShaderRegistry create_shader_registry(const denox::dnx::Model *dnx);
+ShaderRegistry create_shader_registry(const denox::dnx::Model *dnx, std::string &basename);
 
 } // namespace vkdt_denox


### PR DESCRIPTION
adds `--basename <variant>` to the cli. user has to limit this to say 4 chars to be safe against dt_token overflow.

with this in place you can easily generate multiple networks for the same module and offer options.

(there are a few stray commits extra in the hitsory which i believe fix some logic error)